### PR TITLE
Documented CaseTypeAttribute to silence StyleCopAnalyzer errors in referencing projects

### DIFF
--- a/Source/Sundew.DiscriminatedUnions/CaseTypeAttribute.cs
+++ b/Source/Sundew.DiscriminatedUnions/CaseTypeAttribute.cs
@@ -9,15 +9,25 @@ namespace Sundew.DiscriminatedUnions;
 
 using System;
 
+/// <summary>
+/// Indicates the case type constructed by a factory method.
+/// </summary>
 [AttributeUsage(validOn: AttributeTargets.Method, AllowMultiple = false)]
 #pragma warning disable SA1649 // File header file name documentation should match file name
 internal class CaseTypeAttribute : Attribute
 #pragma warning restore SA1649 // File header file name documentation should match file name
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CaseTypeAttribute"/> class.
+    /// </summary>
+    /// <param name="caseType">The case type.</param>
     public CaseTypeAttribute(Type caseType)
     {
         this.CaseType = caseType;
     }
 
+    /// <summary>
+    /// Gets the case type.
+    /// </summary>
     public Type CaseType { get; }
 }


### PR DESCRIPTION
This might be a Roslyn bug as StyleCopAnalyzers should not see the files per:
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/feea263906c6ac13b832dbde2c2d15901795b6fb/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1649FileNameMustMatchTypeName.cs#L55

ConfigureGeneratedCodeAnalysis is configured with none and none is defined as "Disable analyzer action callbacks and diagnostic reporting for generated code"

https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.diagnostics.generatedcodeanalysisflags?view=roslyn-dotnet-4.3.0